### PR TITLE
:sparkels: show logs of request bodies for unexpected paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
@@ -751,9 +751,9 @@ checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -762,21 +762,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,4 +1,5 @@
 pub mod articles;
 pub mod atcoder;
 pub mod health_check;
+pub mod undefined;
 pub mod wakatime;

--- a/src/routes/undefined.rs
+++ b/src/routes/undefined.rs
@@ -1,0 +1,11 @@
+use actix_web::{web, HttpResponse};
+use ulid::Ulid;
+
+#[allow(dead_code)]
+pub async fn undefined(req: web::Bytes) -> HttpResponse {
+    let req_id = Ulid::new().to_string();
+    let body = String::from_utf8(req.to_vec()).unwrap();
+    let req_span = tracing::warn_span!("maybe malicious request", body=%body, req_id=%req_id);
+    let _req_span_guard = req_span.enter();
+    HttpResponse::InternalServerError().finish()
+}

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,7 +1,7 @@
 use crate::configuration::new_reqwest_client;
 use crate::infra::repository::Repositories;
 use crate::routes::health_check::health_check;
-use crate::routes::{articles, atcoder, wakatime};
+use crate::routes::{articles, atcoder, undefined, wakatime};
 use crate::usecase::Usecases;
 use actix_web::dev::Server;
 use actix_web::{web, App, HttpServer};
@@ -36,6 +36,7 @@ pub fn run(
             .service(wakatime::wakatime)
             .service(atcoder::atcoder)
             .app_data(usecases.clone())
+            .default_service(web::route().to(undefined::undefined))
     })
     .listen(listener)?
     .run();

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -24,7 +24,7 @@ where
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(env_filter.into()));
-    let file_appender = tracing_appender::rolling::daily("./", "web.log");
+    let file_appender = tracing_appender::rolling::never("./", "web.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
     let formatting_layer = BunyanFormattingLayer::new(name, non_blocking);
 


### PR DESCRIPTION
# Motivation
- [x] acknowledged some malicious attacks for this service, decided to log request bodies for unexpected paths (e.g. /auth)
- [x] temporary disabled log-rotation feature - to analyze precisely cloud watch.